### PR TITLE
refactor: mark type-only imports

### DIFF
--- a/backend/src/lib/round-manager.ts
+++ b/backend/src/lib/round-manager.ts
@@ -1,4 +1,4 @@
-import { Round, RoundSettings, Player, Question, Answer } from '../types/models';
+import type { Round, RoundSettings, Player, Question, Answer } from '../types/models';
 import { v4 as uuid } from 'uuid';
 
 export class RoundManager {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,7 +4,7 @@ import { createServer } from 'http';
 import { Server } from 'socket.io';
 import { rounds } from './lib/round-manager';
 import { fetchQuestions } from './lib/trivia';
-import { Answer } from './types/models';
+import type { Answer } from './types/models';
 
 export function buildServer() {
   const app = Fastify({ logger: true });


### PR DESCRIPTION
## Summary
- avoid runtime imports by marking models imports as type-only
- keep models.ts as pure type definitions

## Testing
- `npm test`
- `timeout 5 npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_689a756b4818832c8b12e18e91363e31