### PR TITLE
fix backend build and type errors

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "start": "node dist/index.js",
     "test": "vitest run"
   },

--- a/backend/src/lib/round-manager.ts
+++ b/backend/src/lib/round-manager.ts
@@ -67,7 +67,7 @@ export class RoundManager {
       for (const q of round.questions) {
         const ans = p.answers[q.id];
         if (!ans) continue;
-        if (q.type === 'single' || q.type === 'boolean') {
+        if ((q.type === 'single' || q.type === 'boolean') && q.correct !== undefined) {
           if (ans.payload === q.correct) points += 1;
         }
       }

--- a/backend/src/lib/trivia.ts
+++ b/backend/src/lib/trivia.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { Question } from '../types/models';
+import type { Question } from '../types/models';
 import he from 'he';
 import { v4 as uuid } from 'uuid';
 
@@ -17,7 +17,6 @@ function normalizeQuestion(q: any): Question {
     type: q.type === 'boolean' ? 'boolean' : 'single',
     text: he.decode(q.question),
     options: [],
-    correct: undefined,
   };
   if (question.type === 'boolean') {
     question.options = [
@@ -27,12 +26,13 @@ function normalizeQuestion(q: any): Question {
     question.correct = q.correct_answer.toLowerCase();
   } else {
     const answers = [q.correct_answer, ...q.incorrect_answers].map((a: string) => he.decode(a));
-    question.options = answers.map((text) => ({ id: uuid(), text }));
-    question.correct = question.options[0].id;
-    if (answers.length > 0) {
+    const options = answers.map((text) => ({ id: uuid(), text }));
+    question.options = options;
+    if (options.length > 0) {
+      question.correct = options[0]!.id;
       // match correct by value
       const correctText = he.decode(q.correct_answer);
-      const correctOpt = question.options.find((o) => o.text === correctText);
+      const correctOpt = options.find((o) => o.text === correctText);
       if (correctOpt) question.correct = correctOpt.id;
     }
   }

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "target": "ES2020",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": false,
+    "strict": true,
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["tests", "**/*.test.ts", "node_modules"]
+}


### PR DESCRIPTION
## Summary
- add build-only TypeScript config and use it during Docker builds
- tighten backend typing and use type-only imports
- guard question correctness and clean up trivia normalization

## Testing
- `npx tsc -p tsconfig.build.json --pretty false`
- `npm test --workspaces=false`
- `npm run build`
- `npm start & sleep 1; kill $!`
- `npm run dev & sleep 1; kill $!`
- `npm run dev & sleep 2; kill $!` (from frontend)
- `docker compose build --no-cache` (fails: command not found)
- `npm run compose:up` (fails: sh: 1: docker: not found)


------
https://chatgpt.com/codex/tasks/task_e_689a79396ef0832cb65a3c48702b1ee9