### PR TITLE
feat: improve api proxy and json handling

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -5,10 +5,7 @@ RUN npm install
 COPY frontend .
 RUN npm run build
 
-FROM node:20-alpine
-WORKDIR /app
-COPY --from=build /app/dist ./dist
-RUN npm install -g serve
-ENV FRONTEND_PORT=5173
-EXPOSE 5173
-CMD ["serve", "-s", "dist", "-l", "5173"]
+FROM nginx:alpine
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,7 +1,11 @@
 import { buildServer } from './server.js';
 
-const { httpServer } = buildServer();
+const { app } = buildServer();
 const port = Number(process.env.BACKEND_PORT || 8080);
-httpServer.listen(port, '0.0.0.0', () => {
+app.listen({ port, host: '0.0.0.0' }, (err) => {
+  if (err) {
+    app.log.error(err);
+    process.exit(1);
+  }
   console.log('backend listening on', port);
 });

--- a/backend/src/lib/round-manager.ts
+++ b/backend/src/lib/round-manager.ts
@@ -61,19 +61,20 @@ export class RoundManager {
     round.status = 'ended';
   }
 
-  getResults(round: Round) {
-  const scores = Array.from(round.players.values()).map((p: Player) => {
-      let points = 0;
-      for (const q of round.questions) {
-        const ans = p.answers[q.id];
-        if (!ans) continue;
-        if ((q.type === 'single' || q.type === 'boolean') && q.correct !== undefined) {
-          if (ans.payload === q.correct) points += 1;
+  getResults(round: Round): { playerId: string; name: string; points: number }[] {
+    const scores: { playerId: string; name: string; points: number }[] =
+      Array.from(round.players.values()).map((p: Player) => {
+        let points = 0;
+        for (const q of round.questions) {
+          const ans = p.answers[q.id];
+          if (!ans) continue;
+          if ((q.type === 'single' || q.type === 'boolean') && q.correct !== undefined) {
+            if (ans.payload === q.correct) points += 1;
+          }
         }
-      }
-      return { playerId: p.id, name: p.name, points };
-    });
-  scores.sort((a: { points: number }, b: { points: number }) => b.points - a.points);
+        return { playerId: p.id, name: p.name, points };
+      });
+    scores.sort((a, b) => b.points - a.points);
     return scores;
   }
 }

--- a/backend/src/lib/trivia.ts
+++ b/backend/src/lib/trivia.ts
@@ -23,13 +23,13 @@ function normalizeQuestion(q: any): Question {
       { id: 'true', text: 'True' },
       { id: 'false', text: 'False' },
     ];
-  question.correct = q.correct_answer ? q.correct_answer.toLowerCase() : undefined;
+    question.correct = q.correct_answer ? q.correct_answer.toLowerCase() : undefined;
   } else {
     const answers = [q.correct_answer, ...q.incorrect_answers].map((a: string) => he.decode(a));
     const options = answers.map((text) => ({ id: uuid(), text }));
     question.options = options;
     if (options.length > 0) {
-      question.correct = options[0]!.id;
+      question.correct = options[0].id;
       // match correct by value
       const correctText = he.decode(q.correct_answer);
       const correctOpt = options.find((o) => o.text === correctText);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,6 +1,5 @@
 import Fastify from 'fastify';
 import fastifyCors from '@fastify/cors';
-import { createServer } from 'http';
 import { Server } from 'socket.io';
 import { rounds } from './lib/round-manager.js';
 import { fetchQuestions } from './lib/trivia.js';
@@ -10,8 +9,7 @@ export function buildServer() {
   const app = Fastify({ logger: true });
   app.register(fastifyCors, { origin: true, credentials: true });
 
-  const httpServer = createServer(app as any);
-  const io = new Server(httpServer, { cors: { origin: '*' } });
+  const io = new Server(app.server, { cors: { origin: '*' } });
 
   io.on('connection', (socket) => {
     socket.on('join', ({ roundId, playerId }) => {
@@ -30,39 +28,54 @@ export function buildServer() {
     });
   });
 
+  app.get('/api/health', async (_req, reply) => {
+    reply.type('application/json').send({ ok: true });
+  });
+
   app.post('/api/rounds', async (req, reply) => {
     const body: any = req.body;
     const hostName = body.hostName || 'Host';
     const { round, hostId } = rounds.createRound(hostName, body.settings || {});
-    reply.send({ roundId: round.id, joinCode: round.joinCode, settings: round.settings, hostId });
+    reply.type('application/json').send({ roundId: round.id, joinCode: round.joinCode, settings: round.settings, hostId });
   });
 
   app.post('/api/rounds/:id/join', async (req, reply) => {
     const round = rounds.getRound((req.params as any).id);
-    if (!round) return reply.code(404).send({ error: 'NOT_FOUND' });
-    if (round.status !== 'lobby') return reply.code(409).send({ error: 'ROUND_ALREADY_STARTED' });
+    if (!round) return reply.code(404).type('application/json').send({ error: 'NOT_FOUND' });
+    if (round.status !== 'lobby') return reply.code(409).type('application/json').send({ error: 'ROUND_ALREADY_STARTED' });
     const body: any = req.body;
     const player = rounds.joinRound(round, body.playerName);
-    reply.send({ playerId: player.id, roundId: round.id, roundSummary: { settings: round.settings } });
+    reply.type('application/json').send({ playerId: player.id, roundId: round.id, roundSummary: { settings: round.settings } });
   });
 
   app.get('/api/rounds/:id/questions', async (req, reply) => {
     const round = rounds.getRound((req.params as any).id);
-    if (!round) return reply.code(404).send({ error: 'NOT_FOUND' });
+    if (!round) return reply.code(404).type('application/json').send({ error: 'NOT_FOUND' });
     if (round.questions.length === 0) {
       const qs = await fetchQuestions(round.settings.numQuestions, round.settings.category || '9', round.settings.difficulty || 'medium', round.settings.language || 'de');
       rounds.startRound(round, qs);
     }
-  reply.send(round.questions.map((q: any) => ({ id: q.id, type: q.type, text: q.text, options: q.options })));
+    reply
+      .type('application/json')
+      .send(round.questions.map((q: any) => ({ id: q.id, type: q.type, text: q.text, options: q.options })));
   });
 
   app.post('/api/rounds/:id/finish', async (req, reply) => {
     const round = rounds.getRound((req.params as any).id);
-    if (!round) return reply.code(404).send({ error: 'NOT_FOUND' });
+    if (!round) return reply.code(404).type('application/json').send({ error: 'NOT_FOUND' });
     rounds.endRound(round);
     const ranking = rounds.getResults(round);
-    reply.send({ ok: true, ranking });
+    reply.type('application/json').send({ ok: true, ranking });
   });
 
-  return { app, httpServer };
+  app.setNotFoundHandler((req, reply) => {
+    reply.code(404).type('application/json').send({ error: 'Not found' });
+  });
+
+  app.setErrorHandler((error, _req, reply) => {
+    app.log.error(error);
+    reply.code(500).type('application/json').send({ error: error.message });
+  });
+
+  return { app };
 }

--- a/backend/src/types/models.ts
+++ b/backend/src/types/models.ts
@@ -5,6 +5,7 @@ export interface Question {
   type: QuestionType;
   text: string;
   options?: { id: string; text: string }[];
+  // optional: external APIs may omit the correct answer
   correct?: string[] | string | number;
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,23 +7,14 @@ services:
       - .env
     ports:
       - "8080:8080"
-  frontend:
+  nginx:
     build:
       context: .
       dockerfile: Dockerfile.frontend
-    env_file:
-      - .env
-    ports:
-      - "5173:5173"
-  nginx:
-    image: nginx:alpine
     ports:
       - "80:80"
-    volumes:
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
       - backend
-      - frontend
   redis:
     image: redis:alpine
     ports:

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+VITE_API_BASE=/api

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_API_BASE=/api

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,18 @@
+const base = (import.meta.env.VITE_API_BASE || '') as string;
+
+export async function api<T = unknown>(path: string, options?: RequestInit): Promise<T> {
+  const url = base.replace(/\/$/, '') + path;
+  const res = await fetch(url, options);
+  const contentType = res.headers.get('content-type') || '';
+  let data: any;
+  if (contentType.includes('application/json')) {
+    data = await res.json();
+  } else {
+    data = await res.text();
+  }
+  if (!res.ok) {
+    const message = typeof data === 'string' && data ? data : (data?.error || res.statusText);
+    throw new Error(message);
+  }
+  return data as T;
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { api } from '../lib/api';
 
 export default function Home() {
   const navigate = useNavigate();
@@ -10,12 +11,14 @@ export default function Home() {
   const [shuffle, setShuffle] = useState(false);
 
   async function createRound() {
-    const res = await fetch('/api/rounds', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ hostName: 'Host', settings: { numQuestions, difficulty, language, timeLimitSec, shuffle } }),
-    });
-    const data = await res.json();
+    const data = await api<{ roundId: string }>(
+      '/rounds',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ hostName: 'Host', settings: { numQuestions, difficulty, language, timeLimitSec, shuffle } }),
+      }
+    );
     navigate(`/lobby/${data.roundId}`);
   }
 

--- a/frontend/src/pages/Join.tsx
+++ b/frontend/src/pages/Join.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { api } from '../lib/api';
 
 export default function Join() {
   const { code } = useParams();
@@ -7,17 +8,19 @@ export default function Join() {
   const [name, setName] = useState('');
 
   async function join() {
-    const res = await fetch(`/api/rounds/${code}/join`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ playerName: name }),
-    });
-    if (res.status === 409) {
-      alert('Runde bereits gestartet');
-      return;
+    try {
+      const data = await api<{ roundId: string; playerId: string }>(
+        `/rounds/${code}/join`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ playerName: name }),
+        }
+      );
+      navigate(`/lobby/${data.roundId}?player=${data.playerId}`);
+    } catch (err: any) {
+      alert(err.message === 'ROUND_ALREADY_STARTED' ? 'Runde bereits gestartet' : err.message);
     }
-    const data = await res.json();
-    navigate(`/lobby/${data.roundId}?player=${data.playerId}`);
   }
 
   return (

--- a/frontend/src/pages/Play.tsx
+++ b/frontend/src/pages/Play.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { io } from 'socket.io-client';
+import { api } from '../lib/api';
 
 interface Question {
   id: string;
@@ -17,7 +18,7 @@ export default function Play() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    fetch(`/api/rounds/${id}/questions`).then(r => r.json()).then(setQuestions);
+    api<Question[]>(`/rounds/${id}/questions`).then(setQuestions).catch(console.error);
   }, [id]);
 
   const socket = io('/', { path: '/socket.io' });
@@ -31,8 +32,7 @@ export default function Play() {
   }
 
   async function finish() {
-    const res = await fetch(`/api/rounds/${id}/finish`, { method: 'POST' });
-    const data = await res.json();
+    const data = await api(`/rounds/${id}/finish`, { method: 'POST' });
     navigate(`/result/${id}`, { state: data });
   }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,10 +5,16 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/api': 'http://backend:8080',
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        secure: false,
+      },
       '/socket.io': {
-        target: 'http://backend:8080',
+        target: 'http://localhost:8080',
         ws: true,
+        changeOrigin: true,
+        secure: false,
       },
     },
   },

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -10,6 +10,7 @@ server {
     proxy_set_header Connection "upgrade";
   }
   location / {
-    proxy_pass http://frontend:5173/;
+    root /usr/share/nginx/html;
+    try_files $uri $uri/ /index.html;
   }
 }


### PR DESCRIPTION
## Summary
- forward `/api` and socket traffic to backend in development
- use fetch wrapper with JSON/error checks
- ensure backend and nginx always respond with JSON

## Testing
- `cd frontend && npm i && npm run dev`
- `cd backend && npm i && npm run dev`
- `curl -s http://127.0.0.1:8080/api/health`
- `docker compose build --no-cache` *(fails: `command not found: docker`)*

------
https://chatgpt.com/codex/tasks/task_e_689a85bd0c18832ca4bdd7d8056aa39c